### PR TITLE
Add support for excluding specific file extensions in processing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
 name: Tests
+# act -j test --container-architecture linux/amd64 -P ubuntu-latest=catthehacker/ubuntu:act-latest
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ readium /path/to/directory --exclude-dir build --exclude-dir temp
 # Include additional file extensions
 readium /path/to/directory --include-ext .cfg --include-ext .conf
 
+# Exclude specific file extensions (can be specified multiple times)
+readium /path/to/directory --exclude-ext .json --exclude-ext .yml
+
 # Enable debug mode for detailed processing information
 readium /path/to/directory --debug
 
@@ -212,6 +215,9 @@ config = ReadConfig(
     # File extensions to include (extends default set)
     include_extensions={'.custom', '.special'},
 
+    # File extensions to exclude (takes precedence over include_extensions)
+    exclude_extensions={'.json', '.yml'},
+
     # Target specific subdirectory
     target_dir='docs',
 
@@ -268,6 +274,8 @@ DEFAULT_INCLUDE_EXTENSIONS = {
     # (Many more included - see config.py for complete list)
 }
 ```
+
+**Note:** If a file extension is specified in both `include_extensions` and `exclude_extensions`, the exclusion takes precedence and files with that extension will not be processed.
 
 #### Default MarkItDown Extensions
 ```python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "readium"
-version = "0.3.1"
+version = "0.4.0"
 description = "A tool to extract and analyze documentation from repositories, directories, and URLs"
 authors = [
     {name = "Pablo Toledo", email = "pablotoledo@users.noreply.github.com"}

--- a/src/readium/cli.py
+++ b/src/readium/cli.py
@@ -39,6 +39,9 @@ Examples:
 
     # Generate split files from a webpage
     readium https://example.com/docs --split-output ./markdown-files/
+
+    # Exclude specific file extensions
+    readium /path/to/directory --exclude-ext .json --exclude-ext .yml
 """
 )
 @click.argument("path", type=str)
@@ -82,6 +85,12 @@ Examples:
     help="URL processing mode: 'full' preserves all content, 'clean' extracts main content only (default: clean)",
 )
 @click.option(
+    "--exclude-ext",
+    "-e",
+    multiple=True,
+    help="File extensions to exclude from processing (can be specified multiple times, e.g. --exclude-ext .json --exclude-ext .yml)",
+)
+@click.option(
     "--debug/--no-debug",
     "-d/-D",
     default=False,
@@ -96,6 +105,7 @@ def main(
     split_output: str,
     exclude_dir: tuple,
     include_ext: tuple,
+    exclude_ext: tuple,
     url_mode: str,
     debug: bool,
 ):
@@ -109,6 +119,7 @@ def main(
             max_file_size=max_size,
             exclude_dirs=DEFAULT_EXCLUDE_DIRS | set(exclude_dir),
             include_extensions=DEFAULT_INCLUDE_EXTENSIONS | set(include_ext),
+            exclude_extensions=set(exclude_ext),
             target_dir=target_dir,
             url_mode=cast(
                 URL_MODES, url_mode

--- a/src/readium/config.py
+++ b/src/readium/config.py
@@ -160,7 +160,13 @@ URL_MODES = Literal["full", "clean"]
 
 @dataclass
 class ReadConfig:
-    """Configuration for document reading"""
+    """Configuration for document reading
+
+    Attributes
+    ----------
+    exclude_extensions : Set[str]
+        File extensions to exclude from processing (takes precedence over include_extensions).
+    """
 
     max_file_size: int = 5 * 1024 * 1024  # 5MB default
     exclude_dirs: Set[str] = field(default_factory=lambda: DEFAULT_EXCLUDE_DIRS.copy())
@@ -170,6 +176,7 @@ class ReadConfig:
     include_extensions: Set[str] = field(
         default_factory=lambda: DEFAULT_INCLUDE_EXTENSIONS.copy()
     )
+    exclude_extensions: Set[str] = field(default_factory=set)
     target_dir: Optional[str] = None
     use_markitdown: bool = False
     markitdown_extensions: Optional[Set[str]] = field(

--- a/src/readium/core.py
+++ b/src/readium/core.py
@@ -237,6 +237,11 @@ class Readium:
             self.log_debug(f"Excluding {path} due to exclude patterns")
             return False
 
+        # NEW: Check if the file extension is in the excluded extensions (case-insensitive)
+        if file_ext in {ext.lower() for ext in self.config.exclude_extensions}:
+            self.log_debug(f"Excluding {path} due to excluded extension {file_ext}")
+            return False
+
         # Check size
         if self.config.max_file_size >= 0:
             try:

--- a/tests/test_extension_exclusion.py
+++ b/tests/test_extension_exclusion.py
@@ -1,0 +1,147 @@
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from readium.cli import main
+from readium.config import ReadConfig
+from readium.core import Readium
+
+
+@pytest.fixture
+def temp_dir_with_files():
+    """Create a temporary directory with test files of various extensions"""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        path = Path(tmp_dir)
+        # Create test files with different extensions
+        files = {
+            "doc1.md": "# Test Markdown",
+            "doc2.txt": "Plain text file",
+            "code.py": "def test(): pass",
+            "config.json": '{"key": "value"}',
+            "data.yml": "key: value",
+            "styles.css": "body { color: black; }",
+        }
+        for name, content in files.items():
+            file_path = path / name
+            file_path.write_text(content)
+        yield path
+
+
+def test_exclude_extensions_basic(temp_dir_with_files):
+    """Test basic exclusion of a single file extension"""
+    config = ReadConfig(exclude_extensions={".json"})
+    reader = Readium(config)
+    summary, tree, content = reader.read_docs(temp_dir_with_files)
+    assert "Files processed:" in summary
+    assert "doc1.md" in tree
+    assert "code.py" in tree
+    assert "config.json" not in tree
+    assert "# Test Markdown" in content
+    assert "def test():" in content
+    assert '"key": "value"' not in content
+
+
+def test_exclude_extensions_multiple(temp_dir_with_files):
+    """Test exclusion of multiple file extensions"""
+    config = ReadConfig(exclude_extensions={".json", ".yml"})
+    reader = Readium(config)
+    summary, tree, content = reader.read_docs(temp_dir_with_files)
+    assert "Files processed:" in summary
+    assert "doc1.md" in tree
+    assert "code.py" in tree
+    assert "config.json" not in tree
+    assert "data.yml" not in tree
+    # .css is not in default include_extensions, so it should not be in tree
+
+
+def test_exclude_and_include_extensions(temp_dir_with_files):
+    """Test interaction between include and exclude extensions"""
+    config = ReadConfig(
+        include_extensions={".md", ".json"}, exclude_extensions={".json"}
+    )
+    reader = Readium(config)
+    summary, tree, content = reader.read_docs(temp_dir_with_files)
+    assert "Files processed:" in summary
+    assert "doc1.md" in tree
+    assert "code.py" not in tree
+    assert "config.json" not in tree
+    assert "data.yml" not in tree
+    assert "styles.css" not in tree
+    assert "# Test Markdown" in content
+
+
+def test_case_insensitive_extension_matching(temp_dir_with_files):
+    """Test that extension exclusion is case-insensitive"""
+    uppercase_file = temp_dir_with_files / "test.JSON"
+    uppercase_file.write_text('{"uppercase": true}')
+    config = ReadConfig(exclude_extensions={".json"})
+    reader = Readium(config)
+    summary, tree, content = reader.read_docs(temp_dir_with_files)
+    assert "config.json" not in tree
+    assert "test.JSON" not in tree
+
+
+def test_cli_exclude_extensions(temp_dir_with_files):
+    """Test CLI interface with exclude-ext option"""
+    runner = CliRunner()
+    result = runner.invoke(
+        main,
+        [
+            str(temp_dir_with_files),
+            "--exclude-ext",
+            ".json",
+            "--exclude-ext",
+            ".yml",
+            "--debug",
+        ],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0
+    # Extract the "Tree" section from output for assertions
+    tree_start = result.output.find("Tree:")
+    content_start = result.output.find("Content:")
+    tree_section = (
+        result.output[tree_start:content_start]
+        if tree_start != -1 and content_start != -1
+        else result.output
+    )
+    assert "doc1.md" in tree_section
+    assert "code.py" in tree_section
+    assert "config.json" not in tree_section
+    assert "data.yml" not in tree_section
+
+
+@patch("readium.core.clone_repository")
+def test_exclude_extensions_with_git(mock_clone, temp_dir_with_files):
+    """Test extension exclusion with git repositories"""
+    mock_clone.side_effect = lambda url, target_dir, branch=None: None
+    config = ReadConfig(exclude_extensions={".json"})
+    reader = Readium(config)
+    with patch.object(reader, "_process_directory") as mock_process:
+        mock_process.return_value = (
+            "Summary",
+            "Tree without config.json",
+            "Content without JSON",
+        )
+        summary, tree, content = reader.read_docs("https://github.com/fake/repo.git")
+        mock_process.assert_called_once()
+        assert reader.config.exclude_extensions == {".json"}
+
+
+def test_exclude_all_extensions(temp_dir_with_files):
+    """Test excluding all file extensions to ensure no files are processed"""
+    all_extensions = {
+        os.path.splitext(f)[1].lower()
+        for f in os.listdir(temp_dir_with_files)
+        if "." in f
+    }
+    config = ReadConfig(exclude_extensions=all_extensions)
+    reader = Readium(config)
+    summary, tree, content = reader.read_docs(temp_dir_with_files)
+    assert "Files processed: 0" in summary
+    assert "Documentation Structure:" in tree
+    assert len(content.strip()) == 0


### PR DESCRIPTION
This pull request introduces a new feature to exclude specific file extensions from processing in the `readium` tool. The changes include updates to the CLI, configuration, core logic, and documentation, as well as the addition of comprehensive tests to ensure the feature works as expected.

### New Feature: Exclude File Extensions

**CLI and Configuration Updates:**
* Added a new `--exclude-ext` option to the CLI, allowing users to specify file extensions to exclude from processing. This option can be used multiple times (e.g., `--exclude-ext .json --exclude-ext .yml`) (`src/readium/cli.py`, [src/readium/cli.pyR87-R92](diffhunk://#diff-dd5297394964aec9f815524331c0055e4aba0cb0da2199353565d58af0f2df54R87-R92)).
* Updated the `ReadConfig` class to include an `exclude_extensions` attribute, which takes precedence over `include_extensions` during processing (`src/readium/config.py`, [src/readium/config.pyR179](diffhunk://#diff-e9a58bfb8d75e28a190d77a108662be33cd59cff88915a6fdd08147dd4f66021R179)).
* Documented the new `exclude_extensions` attribute in the `ReadConfig` docstring (`src/readium/config.py`, [src/readium/config.pyL163-R169](diffhunk://#diff-e9a58bfb8d75e28a190d77a108662be33cd59cff88915a6fdd08147dd4f66021L163-R169)).

**Core Logic Enhancements:**
* Modified the `should_process_file` method to check for excluded extensions (case-insensitive) and skip processing files with those extensions (`src/readium/core.py`, [src/readium/core.pyR240-R244](diffhunk://#diff-11e9da32e2b7c37057b3a2b7d58d984687be7c623c8e4653b167d3d5929b864fR240-R244)).

**Documentation:**
* Updated the `README.md` to explain the new `--exclude-ext` option and clarify that exclusions take precedence over inclusions (`README.md`, [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R91-R93) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R218-R220) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R278-R279).

### Testing

* Added a new test file, `tests/test_extension_exclusion.py`, with multiple test cases to validate the behavior of the `exclude_extensions` feature:
  - Basic exclusion of single and multiple extensions.
  - Interaction between `include_extensions` and `exclude_extensions`.
  - Case-insensitive matching of extensions.
  - CLI integration tests for the `--exclude-ext` option.
  - Tests for excluding all extensions and ensuring no files are processed.
  - Tests for extension exclusion in Git repositories (`tests/test_extension_exclusion.py`, [tests/test_extension_exclusion.pyR1-R147](diffhunk://#diff-3ba9735a12bfb088dc43a7d36e360e9912c01eaccfb445d683cd925d83c3d87bR1-R147)).