### PR TITLE
Solving issues found at martkitdown integration and exclude-dir argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,35 @@ A powerful Python tool for extracting, analyzing, and converting documentation f
   - Support for tables, links, and images in converted content
 - 🔄 **Convert multiple document formats** to Markdown using MarkItDown integration
 - 🎯 **Target specific subdirectories** for focused analysis
+
+## 🔄 MarkItDown Integration
+
+Readium can use [MarkItDown](https://github.com/microsoft/markitdown) to convert a wide range of document formats directly to Markdown, including:
+
+- PDF (`.pdf`)
+- Word (`.docx`)
+- Excel (`.xlsx`, `.xls`)
+- PowerPoint (`.pptx`)
+- HTML (`.html`, `.htm`)
+- Outlook messages (`.msg`)
+
+To enable this feature, use the `--use-markitdown` option in the CLI or set `use_markitdown=True` in the Python API. MarkItDown will be used automatically for all compatible files.
+
+**Note:** The `markitdown` Python package must be installed. It is included as a dependency, but you can install it manually with:
+```bash
+pip install markitdown
+```
+
+**Example CLI usage:**
+```bash
+readium /path/to/directory --use-markitdown
+```
+
+When enabled, the summary will indicate:
+```
+Using MarkItDown for compatible files
+MarkItDown extensions: .pdf, .docx, .xlsx, .pptx, .html, .msg
+```
 - ⚡ **Process a wide range of file types**:
   - Documentation files (`.md`, `.mdx`, `.rst`, `.txt`)
   - Code files (`.py`, `.js`, `.java`, etc.)
@@ -70,7 +99,7 @@ readium https://example.com/documentation
 # Save output to a file
 readium /path/to/directory -o output.md
 
-# Enable MarkItDown integration
+# Enable MarkItDown integration (for PDF, DOCX, etc.)
 readium /path/to/directory --use-markitdown
 
 # Focus on specific subdirectory
@@ -82,11 +111,16 @@ readium /path/to/directory --target-dir docs/
 # Customize file size limit (e.g., 10MB)
 readium /path/to/directory --max-size 10485760
 
-# Add custom directories to exclude
+# Add custom directories to exclude (can be specified multiple times)
 readium /path/to/directory --exclude-dir build --exclude-dir temp
+
+# Or using the short form -x (can be repeated)
+readium /path/to/directory -x build -x temp
 
 # Include additional file extensions
 readium /path/to/directory --include-ext .cfg --include-ext .conf
+
+# The CLI will print the final list of excluded directories at runtime.
 
 # Exclude specific file extensions (can be specified multiple times)
 readium /path/to/directory --exclude-ext .json --exclude-ext .yml
@@ -103,6 +137,10 @@ readium https://example.com/docs --url-mode full
 # Process URL with main content extraction (default)
 readium https://example.com/docs --url-mode clean
 ```
+
+**Note:**
+- Do not use empty values with `-x`/`--exclude-dir`. Each value must be a valid directory name.
+- The CLI will display the final list of excluded directories before processing.
 
 ### Python API
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "readium"
-version = "0.4.0"
+version = "0.4.1"
 description = "A tool to extract and analyze documentation from repositories, directories, and URLs"
 authors = [
     {name = "Pablo Toledo", email = "pablotoledo@users.noreply.github.com"}

--- a/tests/test_readium.py
+++ b/tests/test_readium.py
@@ -202,6 +202,21 @@ def test_read_docs_with_markitdown(mock_markitdown, sample_files, sample_pdf):
     assert "Converted content" in content
 
 
+def test_markitdown_integration_real(sample_pdf, sample_files):
+    """Test real integration with MarkItDown using an actual PDF file (no mocks)"""
+    config = ReadConfig(
+        use_markitdown=True,
+        markitdown_extensions={".pdf"},
+        include_extensions=set(),  # Solo procesar PDFs
+        debug=True,
+    )
+    reader = Readium(config)
+    summary, tree, content = reader.read_docs(sample_files)
+    # El PDF debe aparecer en el árbol y el contenido debe contener alguna marca de conversión
+    assert "document.pdf" in tree
+    assert "Using MarkItDown" in summary or "MarkItDown" in content or "PDF" in content
+
+
 # Integration tests
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -16,3 +16,50 @@ def test_help_includes_examples():
     result = runner.invoke(main, ["--help"])
     assert "Examples:" in result.output
     assert "Process a local directory" in result.output
+
+
+def test_exclude_dir_single(monkeypatch):
+    """Test using -x once passes the value to the config."""
+    runner = CliRunner()
+    # Patch Readium.read_docs to avoid actual processing
+    monkeypatch.setattr(
+        "readium.core.Readium.read_docs",
+        lambda self, path, branch=None: ("summary", "tree", "content"),
+    )
+    result = runner.invoke(main, [".", "-x", "dir1"])
+    assert result.exit_code == 0
+    # No error should occur, and the CLI should run
+
+
+def test_exclude_dir_multiple(monkeypatch):
+    """Test using -x multiple times passes all values to the config."""
+    runner = CliRunner()
+    monkeypatch.setattr(
+        "readium.core.Readium.read_docs",
+        lambda self, path, branch=None: ("summary", "tree", "content"),
+    )
+    result = runner.invoke(main, [".", "-x", "dir1", "-x", "dir2"])
+    assert result.exit_code == 0
+
+
+def test_exclude_dir_duplicates(monkeypatch):
+    """Test using -x with duplicate values does not cause error."""
+    runner = CliRunner()
+    monkeypatch.setattr(
+        "readium.core.Readium.read_docs",
+        lambda self, path, branch=None: ("summary", "tree", "content"),
+    )
+    result = runner.invoke(main, [".", "-x", "dir1", "-x", "dir1"])
+    assert result.exit_code == 0
+
+
+def test_exclude_dir_empty_value(monkeypatch):
+    """Test using -x with an empty value should fail or warn."""
+    runner = CliRunner()
+    monkeypatch.setattr(
+        "readium.core.Readium.read_docs",
+        lambda self, path, branch=None: ("summary", "tree", "content"),
+    )
+    result = runner.invoke(main, [".", "-x", ""])
+    # Should fail or print an error message
+    assert result.exit_code != 0 or "exclude-dir" in result.output.lower()


### PR DESCRIPTION
This pull request introduces significant enhancements to the `Readium` tool, including the integration of the `MarkItDown` library for document conversion, improvements to the CLI for directory exclusion, and corresponding updates to the documentation and test cases. Below is a summary of the most important changes grouped by theme.

### MarkItDown Integration:
* Added support for `MarkItDown` to convert various document formats (e.g., PDF, DOCX, PPTX) to Markdown. This feature can be enabled via the `--use-markitdown` CLI option or `use_markitdown=True` in the Python API. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21-R49) [[2]](diffhunk://#diff-dd5297394964aec9f815524331c0055e4aba0cb0da2199353565d58af0f2df54R104-R108) [[3]](diffhunk://#diff-dd5297394964aec9f815524331c0055e4aba0cb0da2199353565d58af0f2df54R121-R155)
* Updated the `README.md` with detailed instructions and examples for enabling `MarkItDown` integration, including dependency installation and supported file types. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R21-R49) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L73-R102)

### Directory Exclusion Enhancements:
* Improved the CLI to allow specifying multiple directories for exclusion using the `-x`/`--exclude-dir` option. Added validation to ensure no empty values are provided and included a runtime display of excluded directories. [[1]](diffhunk://#diff-dd5297394964aec9f815524331c0055e4aba0cb0da2199353565d58af0f2df54R121-R155) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L85-R124) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R141-R144)
* Updated documentation with examples of using the `-x` short form for excluding directories and clarified behavior for invalid inputs. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L85-R124) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R141-R144)

### Codebase Updates:
* Modified the `main` function in `src/readium/cli.py` to handle the new `--use-markitdown` option and validate directory exclusion inputs. [[1]](diffhunk://#diff-dd5297394964aec9f815524331c0055e4aba0cb0da2199353565d58af0f2df54R104-R108) [[2]](diffhunk://#diff-dd5297394964aec9f815524331c0055e4aba0cb0da2199353565d58af0f2df54R121-R155)
* Updated the `ReadConfig` object to include `markitdown_extensions` when the feature is enabled.

### Test Suite Enhancements:
* Added integration tests for `MarkItDown` to verify real conversion functionality with actual files.
* Added unit tests for the `-x`/`--exclude-dir` CLI option to ensure correct handling of single, multiple, duplicate, and empty values.

These updates enhance the usability and flexibility of the `Readium` tool, making it more powerful for document processing tasks.