### PR TITLE
Fix exclude-dir sanitization

### DIFF
--- a/src/readium/cli.py
+++ b/src/readium/cli.py
@@ -152,19 +152,21 @@ def main(
             path = args[0]
 
         # Validation: do not allow empty values in --exclude-dir / -x
+        sanitized_exclude = []
         for d in exclude_dir:
             if not d or d.strip() == "":
                 raise click.UsageError(
                     "Empty value detected for --exclude-dir/-x. Please provide a valid directory name."
                 )
+            sanitized_exclude.append(Path(d).name)
 
         # Validate that url_mode is one of the allowed values
         if url_mode not in ("full", "clean"):
             url_mode = "clean"  # Default value if not valid
 
         # Show the user the final list of excluded directories
-        final_exclude_dirs = DEFAULT_EXCLUDE_DIRS | set(exclude_dir)
-        if exclude_dir:
+        final_exclude_dirs = DEFAULT_EXCLUDE_DIRS | set(sanitized_exclude)
+        if sanitized_exclude:
             console.print(
                 f"[yellow]Excluding directories:[/yellow] {', '.join(sorted(final_exclude_dirs))}"
             )

--- a/tests/test_exclude_dir.py
+++ b/tests/test_exclude_dir.py
@@ -1,0 +1,27 @@
+import tempfile
+from pathlib import Path
+from click.testing import CliRunner
+
+from readium.cli import main
+
+
+def test_exclude_dir_with_relative_path():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        path = Path(tmp_dir)
+        (path / "skip").mkdir()
+        (path / "skip" / "a.md").write_text("skip")
+        (path / "keep.md").write_text("keep")
+
+        runner = CliRunner()
+        result = runner.invoke(main, [str(path), "-x", "./skip"])
+        assert result.exit_code == 0
+        # Tree section should not list files inside 'skip'
+        tree_start = result.output.find("Tree:")
+        content_start = result.output.find("Content:")
+        tree_section = (
+            result.output[tree_start:content_start]
+            if tree_start != -1 and content_start != -1
+            else result.output
+        )
+        assert "skip" not in tree_section
+        assert "keep.md" in tree_section


### PR DESCRIPTION
This pull request improves the handling of the `--exclude-dir` (`-x`) option in the `readium` CLI tool by sanitizing directory inputs and adds a corresponding test to ensure proper functionality.

### Enhancements to `--exclude-dir` handling:
* In `src/readium/cli.py`, introduced a `sanitized_exclude` list to store sanitized directory names (using `Path(d).name`) to prevent issues with relative paths or malformed inputs. Updated the logic to use this sanitized list when determining the final set of excluded directories.

### New test for `--exclude-dir`:
* Added a new test case, `test_exclude_dir_with_relative_path`, in `tests/test_exclude_dir.py` to verify that directories specified with relative paths (e.g., `./skip`) are properly excluded. This test uses a temporary directory to simulate a file structure and checks that excluded directories do not appear in the output.